### PR TITLE
readme: add instructions for non-nix-shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ Afterwards, initialize the local Terraform workspace:
 terraform init
 ```
 
+If you aren't using `nix-shell`, you need to source the environment:
+```sh
+set -o allexport
+source .env
+set +o allexport
+```
+
 ## Deploying
 
 ### Deploy locally


### PR DESCRIPTION
This patch adds additional information to the README on necessary instructions for using the `acm-aws` repository without `nix-shell`.

Environment variables stored in the `.env` are necessary for performing many `acm-aws` functions, including usage of the SSH script. Sourcing the `.env` is necessary to be able to use the SSH script.

When logging in with `nix-shell`, the `.env` is automatically sourced, preventing users from having any issues. However, there are currently no indicators that the file needs to be sourced - `.env` is not even mentioned at all in the README. We don't currently specify in the README that `nix-shell` is a requirement - in fact, it is listed as optional/highly recommended - and thus non-nix-shell logins should be supported.

Assuming basic dependencies (jq) are installed (doesn't even need Terraform or AWSCLI2), sourcing the `.env` (with `allexport`, as the file does not currently actually export the environment variables) and `./secrets` is decrypted (with proper permission overrides on the SSH key) is a sufficient condition for being able to log in with SSH.

Signed-off-by: Amy Parker <amy@amyip.net>