### PR TITLE
automatically reset ssh sk permissions, unlock key

### DIFF
--- a/scripts/ssh
+++ b/scripts/ssh
@@ -2,6 +2,12 @@
 . "$(dirname "$0")/lib/init"
 
 main() {
+	if [[ $(dd if=secrets/ssh/id_ed25519 bs=1 skip=1 | head -c 8) == "GITCRYPT" ]]; then
+		git-crypt unlock
+	fi
+	# git doesn't save file mode properly - so we have to override it
+	# this is very common because it's also necessary after any git-crypt operation
+	chmod 600 secrets/ssh/id_ed25519
 	publicIP=$(./scripts/ip "$1")
 	ssh -o 'IdentitiesOnly=yes' -i ./secrets/ssh/id_ed25519 "root@${publicIP}"
 }


### PR DESCRIPTION
This patch resets the permissions of the ssh secret key to 600, which is necessary for ssh to accept the key for use in connecting to the servers. It also automatically prompts for unlock if the repository is still git-crypt locked.

While git claims to track the mode of files, it only tracks two components: file type (file/directory/symlink) and the execute bit. It presumes that the rest of the bits should be set as 644, which breaks ssh because the key permissions need to be 600. Any git-crypt operation (even unlocking an already unlocked repo) also makes doing this necessary.

Signed-off-by: Amy Parker <amy@amyip.net>