### PR TITLE
update nixos to 23.11

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -163,10 +163,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "50aa30a13c4ab5e7ba282da460a3e3d44e9d0eb3",
-        "sha256": "05vmvgjwj75nx7dvp534h3y1zhf2zqddcxpcyjlkrj0zb4id9mcl",
+        "rev": "b94a96839afcc56de3551aa7472b8d9a3e77e05d",
+        "sha256": "1j5vs24bgy2arl342lrh3znc1pdz68kcjp2rpgy3sccpd9sibqqn",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/50aa30a13c4ab5e7ba282da460a3e3d44e9d0eb3.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/b94a96839afcc56de3551aa7472b8d9a3e77e05d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
         "version": "nixos-unstable"
     },


### PR DESCRIPTION
This patch updates NixOS to 23.11 for both cirno and cs306.

Signed-off-by: Amy Parker <amy@amyip.net>