### PR TITLE
cs306: add basic incus config

### DIFF
--- a/servers/cs306/configuration.nix
+++ b/servers/cs306/configuration.nix
@@ -74,5 +74,50 @@
 	# Enable wake-on-LAN for Ethernet.
 	networking.interfaces.enp8s0.wakeOnLan.enable = true;
 
+	# Enable incus with reproducible config
+	# Manual changes will cause irreproducibility - do not edit outside of this!
+	# Test any changes before pushing, particularly with networking
+	virtualisation.incus.enable = true;
+	virtualisation.incus.preseed = {
+		networks = [
+			{
+				config = {
+					"ipv4.address" = "172.16.100.1/24";
+					"ipv4.nat" = "true";
+					"ipv4.firewall" = "false";
+					"ipv6.firewall" = "false";
+				};
+				name = "incusbr0";
+				type = "bridge";
+			}
+		];
+		profiles = [
+			{
+				devices = {
+					eth0 = {
+						name = "eth0";
+						network = "incusbr0";
+						type = "nic";
+					};
+					root = {
+						path = "/";
+						pool = "default";
+						size = "200GiB";
+						type = "disk";
+					};
+				};
+			}
+		];
+		storage_pools = [
+			{
+				config = {
+					source = "/var/lib/incus/storage-pools/default";
+				};
+				driver = "dir";
+				name = "default";
+			}
+		];
+	};
+
 	system.stateVersion = "23.05"; # Did you read the comment?
 }


### PR DESCRIPTION
This patch adds in a basic incus config for CS306 and enables the incus daemon. Configuration is done fully within the nix configuration and not outside; future documentation on working with incus in the 306 context should note the cautions for working with incus (do not make significant networking changes except when necessary, and remember that incus may need to be cleared depending on what changes are made; also, as in general, do not edit manually on the server!)

Signed-off-by: Amy Parker <amy@amyip.net>