### PR TITLE
Caddyfile: cs306 -> cs306-mini

### DIFF
--- a/servers/cirno/Caddyfile
+++ b/servers/cirno/Caddyfile
@@ -68,7 +68,7 @@ spookathon.acmcsuf.com {
 # need to worry about MITM attacks.
 *.acmcsuf.com,
 vps.acmcsuf.com, *.vps.acmcsuf.com {
-	reverse_proxy * http://cs306:80
+	reverse_proxy * http://cs306-mini:80
 }
 
 blinktest.acmcsuf.com {


### PR DESCRIPTION
This patch reroutes wildcard traffic to cs306-mini. Cirno currently routes traffic with an otherwise unknown domain to cs306, which no longer exists! This is necessary for the transition to cs306-mini.